### PR TITLE
Festergut Malleable Goo fixes and suggestions.

### DIFF
--- a/DBM-Icecrown/ThePlagueworks/Festergut.lua
+++ b/DBM-Icecrown/ThePlagueworks/Festergut.lua
@@ -10,12 +10,21 @@ mod:SetMinSyncRevision(20230627000000)
 
 mod:RegisterEventsInCombat(
 	"SPELL_CAST_START 69195 71219 73031 73032",
-	"SPELL_CAST_SUCCESS 69278 71221",
+	-- "SPELL_CAST_SUCCESS 69278 71221", TODO: need to get the Malleable Goo spell IDs from 10, 10HC, 25 and 25HC
+  "SPELL_CAST_SUCCESS",
 	"SPELL_AURA_APPLIED 69279 69166 71912 72219 72551 72552 72553 69240 71218 73019 73020 69291 72101 72102 72103",
 	"SPELL_AURA_APPLIED_DOSE 69166 71912 72219 72551 72552 72553 69291 72101 72102 72103",
 	"SPELL_AURA_REMOVED 69279",
 	"UNIT_SPELLCAST_SUCCEEDED boss1"
 )
+
+local isGooSummonHidden     = true
+local gooCastFrequency    = 10
+
+-- TODO: change the timer for different difficulties
+-- if not self:IsDifficulty("heroic25") then
+--   gooCastFrequency = 15
+-- end
 
 local warnInhaledBlight		= mod:NewStackAnnounce(69166, 3)
 local warnGastricBloat		= mod:NewStackAnnounce(72219, 2, nil, "Tank|Healer")
@@ -38,7 +47,7 @@ local timerPungentBlight	= mod:NewCDTimer(33.5, 69195, nil, nil, nil, 2)		-- Edi
 local timerInhaledBlight	= mod:NewCDTimer(34, 69166, nil, nil, nil, 6, nil, nil, true)	-- Timer is based on Aura. ~9s variance on pull, 1.5s variance [33.5-35.0]. Added "keep" arg (25H Lordaeron 2022/09/04 || 25H Lordaeron 2022/09/25) - 34.2, 34.7, *, 34.2 || 34.3, 33.8, 67.5 [33.5-pungent, 34.0], 34.2
 local timerGastricBloat		= mod:NewTargetTimer(100, 72219, nil, "Tank|Healer", nil, 5, nil, DBM_COMMON_L.TANK_ICON)	-- 100 Seconds until expired
 local timerGastricBloatCD	= mod:NewCDTimer(14, 72219, nil, "Tank|Healer", nil, 5, nil, DBM_COMMON_L.TANK_ICON) -- REVIEW! ~3s variance [13.1 - 16.2]. (25H Lordaeron [2023-04-07]@[19:29:03] || 25H Icecrown [2023-05-28]@[16:21:49]) - "Gastric Bloat-72553-npc:36626-1098 = pull:13.8, 13.1, 13.5, 13.1, 13.2, 14.0, 13.8, 13.4, 13.2, 13.9, 13.4, 13.8 || "Gastric Bloat-72553-npc:36626-752 = pull:13.6, 16.2, 13.4, 13.1, 13.4, 13.3, 14.3, 13.4, 13.1, 14.1, 13.1, 14.8, 13.1
-local timerGooCD			= mod:NewCDTimer(10, 72297, nil, nil, nil, 3)
+local timerGooCD			= mod:NewCDTimer(gooCastFrequency, 72297, nil, nil, nil, 3)
 
 local berserkTimer			= mod:NewBerserkTimer(300)
 
@@ -51,6 +60,9 @@ local gasSporeTargets = {}
 local vileGasTargets = {}
 mod.vb.gasSporeCast = 0
 mod.vb.warnedfailed = false
+local localizedGooNames = {
+  [72550] = GetSpellInfo(72550)
+}
 
 function mod:AnnounceSporeIcons(uId, icon)
 	if self.Options.AnnounceSporeIcons and DBM:IsInGroup() and DBM:GetRaidRank() > 1 then
@@ -82,6 +94,7 @@ function mod:OnCombatStart(delay)
 	if self.Options.RangeFrame then
 		DBM.RangeCheck:Show(10) -- 9.6y is the shortest distance that it doesn't spread (TC test 12/03/2023); set to 10 for safety
 	end
+  -- TODO: Check if first goo aligns with the timer
 	if self:IsHeroic() then
 		timerGooCD:Start(13-delay)
 	end
@@ -110,6 +123,22 @@ function mod:SPELL_CAST_SUCCESS(args)
 			timerGasSporeCD:Start()
 		end
 	end
+
+  if not isGooSummonHidden then
+    return
+  end
+
+  -- TODO: Stop using spell name instead of spell IDs after getting all the Malleable Goo spell IDs from all the difficulties
+  local localizedSpellName = localizedGooNames[args.spellId] or GetSpellInfo(args.spellId)
+
+  if localizedSpellName == localizedGooNames[72550] then
+    localizedGooNames[args.spellId] = localizedSpellName
+
+    timerGooCD:Start()
+    -- TODO: test if special announcements scheduled below actually work
+    specWarnGoo:DelayedShow(gooCastFrequency)
+    specWarnGoo:ScheduleVoice(gooCastFrequency, "watchstep")
+  end
 end
 
 function mod:SPELL_AURA_APPLIED(args)
@@ -181,9 +210,11 @@ end
 
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, spellName)
 	if spellName == GetSpellInfo(72299) then -- Malleable Goo Summon Trigger (10 player normal) (the other 3 spell ids are not needed here since all spells have the same name)
-		DBM:AddMsg("Malleable Goo Summon Trigger UNIT_SPELLCAST_SUCCEEDED unhidden from combat log. Notify Zidras on Discord or GitHub")
+		isGooSummonHidden = false
+    DBM:AddMsg("Malleable Goo Summon Trigger UNIT_SPELLCAST_SUCCEEDED unhidden from combat log. Notify Zidras on Discord or GitHub")
 		specWarnGoo:Show()
 		specWarnGoo:Play("watchstep")
+    -- TODO: Change the frequency value before constructing the timer instead of calculating it here
 		if self:IsDifficulty("heroic25") then
 			timerGooCD:Start()
 		else


### PR DESCRIPTION
The changes were tested on PTR a couple weeks ago on the basic level in 25 heroic, to show the cooldown timer after Malleable Goo explodes. The timer values may be wrong. Code that can be improved is marked with TODO comments. I didn't try to go and fish for spell IDs and timers because you may already have the data.